### PR TITLE
Converted `src/posts/data.js` to TS and Fixed Unit Tests

### DIFF
--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -1,71 +1,111 @@
-'use strict';
-
-const db = require('../database');
-const plugins = require('../plugins');
-const utils = require('../utils');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const db = require("../database");
+const plugins = require("../plugins");
+const utils = require("../utils");
 const intFields = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
     'replies', 'bookmarks',
 ];
-
-module.exports = function (Posts) {
-    Posts.getPostsFields = async function (pids, fields) {
-        if (!Array.isArray(pids) || !pids.length) {
-            return [];
-        }
-        const keys = pids.map(pid => `post:${pid}`);
-        const postData = await db.getObjects(keys, fields);
-        const result = await plugins.hooks.fire('filter:post.getFields', {
-            pids: pids,
-            posts: postData,
-            fields: fields,
-        });
-        result.posts.forEach(post => modifyPost(post, fields));
-        return result.posts;
-    };
-
-    Posts.getPostData = async function (pid) {
-        const posts = await Posts.getPostsFields([pid], []);
-        return posts && posts.length ? posts[0] : null;
-    };
-
-    Posts.getPostsData = async function (pids) {
-        return await Posts.getPostsFields(pids, []);
-    };
-
-    Posts.getPostField = async function (pid, field) {
-        const post = await Posts.getPostFields(pid, [field]);
-        return post ? post[field] : null;
-    };
-
-    Posts.getPostFields = async function (pid, fields) {
-        const posts = await Posts.getPostsFields([pid], fields);
-        return posts ? posts[0] : null;
-    };
-
-    Posts.setPostField = async function (pid, field, value) {
-        await Posts.setPostFields(pid, { [field]: value });
-    };
-
-    Posts.setPostFields = async function (pid, data) {
-        await db.setObject(`post:${pid}`, data);
-        plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
-    };
-};
-
 function modifyPost(post, fields) {
     if (post) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         db.parseIntFields(post, intFields, fields);
         if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
             post.votes = post.upvotes - post.downvotes;
         }
         if (post.hasOwnProperty('timestamp')) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             post.timestampISO = utils.toISOString(post.timestamp);
         }
         if (post.hasOwnProperty('edited')) {
-            post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            post.editedISO = (post.edited !== 0 ? utils.toISOString(post.edited) : '');
         }
     }
 }
+module.exports = function (Posts) {
+    Posts.getPostsFields = function (pids, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!Array.isArray(pids) || !pids.length) {
+                return [];
+            }
+            const keys = pids.map(pid => `post:${pid}`);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const postData = yield db.getObjects(keys, fields);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const result = yield plugins.hooks.fire('filter:post.getFields', {
+                pids: pids,
+                posts: postData,
+                fields: fields,
+            });
+            result.posts.forEach(post => modifyPost(post, fields));
+            return result.posts;
+        });
+    };
+    Posts.getPostData = function (pid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const posts = yield Posts.getPostsFields([pid], []);
+            return posts && posts.length ? posts[0] : null;
+        });
+    };
+    Posts.getPostsData = function (pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield Posts.getPostsFields(pids, []);
+        });
+    };
+    Posts.getPostField = function (pid, field) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const post = yield Posts.getPostFields(pid, [field]);
+            return post ? post[field] : null;
+        });
+    };
+    Posts.getPostFields = function (pid, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const posts = yield Posts.getPostsFields([pid], fields);
+            return posts ? posts[0] : null;
+        });
+    };
+    Posts.setPostField = function (pid, field, value, callback = null) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                yield Posts.setPostFields(pid, { [field]: value });
+                if (callback) {
+                    callback(null);
+                }
+            }
+            catch (err) {
+                const error = err instanceof Error ? err : new Error(err);
+                if (callback) {
+                    callback(error);
+                }
+                else {
+                    throw error;
+                }
+            }
+        });
+    };
+    Posts.setPostFields = function (pid, data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            yield db.setObject(`post:${pid}`, data);
+            yield plugins.hooks.fire('action:post.setFields', { data: Object.assign(Object.assign({}, data), { pid }) });
+        });
+    };
+};

--- a/src/posts/data.ts
+++ b/src/posts/data.ts
@@ -1,0 +1,123 @@
+import db = require('../database');
+import plugins = require('../plugins');
+import utils = require('../utils');
+
+const intFields: string[] = [
+    'uid', 'pid', 'tid', 'deleted', 'timestamp',
+    'upvotes', 'downvotes', 'deleterUid', 'edited',
+    'replies', 'bookmarks',
+];
+
+type Posts = {
+  setPostFields: (pid: string, data: Record<string, string[] | string | number | symbol>) => Promise<void>;
+  setPostField: (pid: string, field: string, value: string[], callback?: (err: Error | null) => void) => Promise<void>;
+  getPostFields: (pid: string, fields: string[]) => Promise<PostData | null>;
+  getPostsFields : (pid: string[], fields: string[]) => Promise<PostData[]>;
+  getPostData: (pid: string) => Promise<PostData | null>
+  getPostsData: (pid: string[]) => Promise<PostData[]>
+  getPostField: (pid: string, field: string) => Promise<PostData[]>
+};
+
+type PostData = {
+  uid: number;
+  pid: string;
+  tid: number;
+  field: string;
+  fields: string[];
+  deleted: number;
+  timestamp: number;
+  upvotes: number;
+  downvotes: number;
+  deleterUid: number;
+  edited: number;
+  replies: number;
+  bookmarks: number;
+  votes?: number;
+  timestampISO?: string;
+  editedISO?: string;
+};
+
+function modifyPost(post: PostData, fields: string[]): void {
+    if (post) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        db.parseIntFields(post, intFields, fields);
+        if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
+            post.votes = post.upvotes - post.downvotes;
+        }
+        if (post.hasOwnProperty('timestamp')) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            post.timestampISO = utils.toISOString(post.timestamp) as string;
+        }
+        if (post.hasOwnProperty('edited')) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            post.editedISO = (post.edited !== 0 ? utils.toISOString(post.edited) : '') as string;
+        }
+    }
+}
+
+module.exports = function (Posts: Posts) {
+    Posts.getPostsFields = async function (pids, fields) {
+        if (!Array.isArray(pids) || !pids.length) {
+            return [];
+        }
+        const keys = pids.map(pid => `post:${pid}`);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const postData = await db.getObjects(keys, fields) as PostData[];
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result = await plugins.hooks.fire('filter:post.getFields', {
+            pids: pids,
+            posts: postData,
+            fields: fields,
+        }) as { posts: PostData[] };
+        result.posts.forEach(post => modifyPost(post, fields));
+        return result.posts;
+    };
+
+    Posts.getPostData = async function (pid) {
+        const posts = await Posts.getPostsFields([pid], []);
+        return posts && posts.length ? posts[0] : null;
+    };
+
+    Posts.getPostsData = async function (pids) {
+        return await Posts.getPostsFields(pids, []);
+    };
+
+    Posts.getPostField = async function (pid, field) {
+        const post = await Posts.getPostFields(pid, [field]);
+        return post ? post[field] as PostData[] : null;
+    };
+
+    Posts.getPostFields = async function (pid, fields) {
+        const posts = await Posts.getPostsFields([pid], fields);
+        return posts ? posts[0] : null;
+    };
+
+    Posts.setPostField = async function (pid, field, value, callback: (err: Error | null) => void = null) {
+        try {
+            await Posts.setPostFields(pid, { [field]: value });
+            if (callback) {
+                callback(null);
+            }
+        } catch (err) {
+            const error = err instanceof Error ? err : new Error(err as string);
+            if (callback) {
+                callback(error);
+            } else {
+                throw error;
+            }
+        }
+    };
+
+    Posts.setPostFields = async function (pid, data) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        await db.setObject(`post:${pid}`, data);
+        await plugins.hooks.fire('action:post.setFields', { data: { ...data, pid } });
+    };
+};
+

--- a/test/posts.js
+++ b/test/posts.js
@@ -153,12 +153,11 @@ describe('Post\'s', () => {
         }
     });
 
-    it('should return falsy if post does not exist', (done) => {
-        posts.getPostData(9999, (err, postData) => {
-            assert.ifError(err);
-            assert.equal(postData, null);
-            done();
-        });
+    // Test case was changed due to it not being in the format of the getPostData's
+    // parameters (pid only).
+    it('should return falsy if post does not exist', async () => {
+        const postData = await posts.getPostData(9999);
+        assert.equal(postData, null);
     });
 
     describe('voting', () => {


### PR DESCRIPTION
Resolves #17 
### Description and Changes
I have taken the file `src/posts/data.js` and converted it into TypeScript (see issue [#17](https://github.com/UCF-CEN-5016/NodeBB-UCF/issues/17)). I have also changed the test case (`test/post.js`) for the function getPostData.

Here are the changes I made in `src/posts/data.js`:
- Created a new type called PostData.
- Initialized a new type called Posts that identifies various methods and their definitions (type definition).
- Type casted variables and return types.
- Suppressed eslint errors from function calls that were not related to the file.
- Changed the parameter of `setPostField` to incorporate a callback field to fit the test case.

Changes made in `test/posts.js`:
- Changed the parameters for the test case involving getPostData by only incorporating the pid; this is to match the original Javascript's fields.

### Reasoning
`src/posts/data.js` did not have a TypeScript file originally so I created a translation for it. This will allow for better support of code editors, typing, and is part of the project to migrate all of the codebase to TypeScript. The change for the test case in `test/posts.js` is due to the odd translation in Javascript that led to weird parameter changes so I adjusted the test case for `getPostData` to suit the original JavaScript. I have also made a slight adjustment due to the test cases for the function `setPostField` to fit the parameters of the test cases by adding a callback error to the parameter so it can pass.

### Testing
This was tested by running both `npm run test` and `npm run lint` and both tests passed.
![image](https://github.com/UCF-CEN-5016/NodeBB-UCF/assets/93550993/cf3148cb-a2b1-4cca-b221-4ce6c13b0624)
![image](https://github.com/UCF-CEN-5016/NodeBB-UCF/assets/93550993/16d3af13-a88d-451e-b106-6186da515af9)
