### PR TITLE
Converted `src/posts/topics.js` from JS to TS 

### DIFF
--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -1,54 +1,78 @@
-
-'use strict';
-
-const topics = require('../topics');
-const user = require('../user');
-const utils = require('../utils');
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const topics = require("../topics");
+const user = require("../user");
+const utils = require("../utils");
 module.exports = function (Posts) {
-    Posts.getPostsFromSet = async function (set, start, stop, uid, reverse) {
-        const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
-        const posts = await Posts.getPostsByPids(pids, uid);
-        return await user.blocks.filter(uid, posts);
-    };
-
-    Posts.isMain = async function (pids) {
-        const isArray = Array.isArray(pids);
-        pids = isArray ? pids : [pids];
-        const postData = await Posts.getPostsFields(pids, ['tid']);
-        const topicData = await topics.getTopicsFields(postData.map(t => t.tid), ['mainPid']);
-        const result = pids.map((pid, i) => parseInt(pid, 10) === parseInt(topicData[i].mainPid, 10));
-        return isArray ? result : result[0];
-    };
-
-    Posts.getTopicFields = async function (pid, fields) {
-        const tid = await Posts.getPostField(pid, 'tid');
-        return await topics.getTopicFields(tid, fields);
-    };
-
-    Posts.generatePostPath = async function (pid, uid) {
-        const paths = await Posts.generatePostPaths([pid], uid);
-        return Array.isArray(paths) && paths.length ? paths[0] : null;
-    };
-
-    Posts.generatePostPaths = async function (pids, uid) {
-        const postData = await Posts.getPostsFields(pids, ['pid', 'tid']);
-        const tids = postData.map(post => post && post.tid);
-        const [indices, topicData] = await Promise.all([
-            Posts.getPostIndices(postData, uid),
-            topics.getTopicsFields(tids, ['slug']),
-        ]);
-
-        const paths = pids.map((pid, index) => {
-            const slug = topicData[index] ? topicData[index].slug : null;
-            const postIndex = utils.isNumber(indices[index]) ? parseInt(indices[index], 10) + 1 : null;
-
-            if (slug && postIndex) {
-                return `/topic/${slug}/${postIndex}`;
-            }
-            return null;
+    Posts.getPostsFromSet = function (set, start, stop, uid, reverse) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const pids = yield Posts.getPidsFromSet(set, start, stop, reverse);
+            const posts = yield Posts.getPostsByPids(pids, uid);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return yield user.blocks.filter(uid, posts);
         });
-
-        return paths;
+    };
+    Posts.isMain = function (pids) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const isArray = Array.isArray(pids);
+            const pidsArray = isArray ? (pids) : [pids];
+            const postData = yield Posts.getPostsFields(pidsArray, ['tid']);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const topicData = yield topics.getTopicsFields(postData.map(t => t.tid), ['mainPid']);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const result = pidsArray.map((pid, i) => pid === topicData[i].mainPid);
+            return isArray ? result : result[0];
+        });
+    };
+    Posts.getTopicFields = function (pid, fields) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const tid = yield Posts.getPostField(pid, 'tid');
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            return yield topics.getTopicFields(tid, fields);
+        });
+    };
+    Posts.generatePostPath = function (pid, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const paths = yield Posts.generatePostPaths([pid], uid);
+            return Array.isArray(paths) && paths.length ? paths[0] : null;
+        });
+    };
+    Posts.generatePostPaths = function (pids, uid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const postData = yield Posts.getPostsFields(pids, ['pid', 'tid']);
+            const tids = postData.map(post => post && post.tid);
+            const [indices, topicData] = yield Promise.all([
+                Posts.getPostIndices(postData, uid),
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                topics.getTopicsFields(tids, ['slug']),
+            ]);
+            const paths = pids.map((pid, index) => {
+                // The next line calls a function in a module that has not been updated to TS yet
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                const slug = (topicData[index] ? topicData[index].slug : null);
+                const postIndex = utils.isNumber(indices[index]) ? indices[index] + 1 : null;
+                if (slug && postIndex) {
+                    return `/topic/${slug}/${postIndex}`;
+                }
+                return null;
+            });
+            return paths;
+        });
     };
 };

--- a/src/posts/topics.ts
+++ b/src/posts/topics.ts
@@ -1,0 +1,94 @@
+import topics = require('../topics');
+import user = require('../user');
+import utils = require('../utils');
+
+type Posts = {
+    getPostsFromSet: (set: string, start: number, stop: number, uid: number, reverse: boolean) => Promise<PostData[]>;
+    getPidsFromSet: (set: string, start: number, stop: number, reverse: boolean) => Promise<number[]>;
+    getPostsByPids: (pids: number[], uid: number) => Promise<PostData[]>;
+    isMain: (pids: number | number[]) => Promise<boolean | boolean[]>;
+    getTopicFields: (pid: number, fields: string[]) => Promise<string[]>;
+    getPostField: (pid: number, field: string) => Promise<number>;
+    generatePostPath: (pid: number, uid: number) => Promise<string | null>;
+    generatePostPaths: (pids: number[], uid: number) => Promise<(string | null)[]>;
+    getPostsFields: (pids: number[], fields: string[]) => Promise<PostData[]>;
+    getPostIndices: (postData: PostData[], uid: number) => Promise<number[]>;
+    getTopicsFields: (tids: number[], fields: string[]) => Promise<PostData>;
+};
+
+interface PostData {
+    pid: number;
+    tid: number;
+    content: string;
+    uid: number;
+    timestamp: number;
+    deleted: boolean;
+    upvotes: number;
+    downvotes: number;
+    votes: number;
+    timestampISO: string;
+    isMainPost: boolean;
+    replies: number;
+}
+
+module.exports = function (Posts: Posts) {
+    Posts.getPostsFromSet = async function (set, start, stop, uid, reverse) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
+        const posts = await Posts.getPostsByPids(pids, uid);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return await user.blocks.filter(uid, posts) as PostData[];
+    };
+
+    Posts.isMain = async function (pids) {
+        const isArray = Array.isArray(pids);
+        const pidsArray = isArray ? (pids) : [pids];
+        const postData = await Posts.getPostsFields(pidsArray, ['tid']);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const topicData = await topics.getTopicsFields(postData.map(t => t.tid), ['mainPid']) as PostData;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result = pidsArray.map((pid, i) => pid === topicData[i].mainPid);
+        return isArray ? result : result[0];
+    };
+
+    Posts.getTopicFields = async function (pid, fields) {
+        const tid = await Posts.getPostField(pid, 'tid');
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        return await topics.getTopicFields(tid, fields) as string[];
+    };
+
+    Posts.generatePostPath = async function (pid, uid) {
+        const paths = await Posts.generatePostPaths([pid], uid);
+        return Array.isArray(paths) && paths.length ? paths[0] : null;
+    };
+
+    Posts.generatePostPaths = async function (pids, uid) {
+        const postData = await Posts.getPostsFields(pids, ['pid', 'tid']);
+        const tids = postData.map(post => post && post.tid);
+        const [indices, topicData]: [number[], PostData] = await Promise.all([
+            Posts.getPostIndices(postData, uid),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            topics.getTopicsFields(tids, ['slug']) as PostData,
+        ]);
+
+        const paths = pids.map((pid, index) => {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            const slug = (topicData[index] ? topicData[index].slug : null) as number;
+            const postIndex = utils.isNumber(indices[index]) ? indices[index] + 1 : null;
+
+            if (slug && postIndex) {
+                return `/topic/${slug}/${postIndex}`;
+            }
+            return null;
+        });
+
+        return paths;
+    };
+};


### PR DESCRIPTION
Resolves #18

## Description
- Translated `src/posts/topics.js` from javascript  to typescript (in `src/posts/topics.ts`)

## Changes
- Initialized an interface variable for `PostData`
- Initialized `Posts` type and outlined the prototypes for all associated child functions
- Specified return types for all functions and assigned types to their parameters
- Type casted to validate the correct type before assignment
- Suppressed eslint errors for unsafe access to any unknown members and calls

## Testing
```
npm run lint
npm run test
```