### PR TITLE
Converted src/controllers/unread.js from JS to TS

### DIFF
--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -88,7 +88,7 @@ function get(req, res) {
         if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-            req.query.page = Math.max(1, Math.min(data.pageCount, page));
+            req.query.page = (Math.max(1, Math.min(data.pageCount, page))).toString();
             return helpers_1.default.redirect(res, `/unread?${querystring_1.default.stringify(req.query)}`);
         }
         // The next line calls a function in a module that has not been updated to TS yet

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -25,17 +25,31 @@ function get(req, res) {
     return __awaiter(this, void 0, void 0, function* () {
         const { cid } = req.query;
         const filter = req.query.filter || '';
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const [categoryData, userSettings, isPrivileged] = yield Promise.all([
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             helpers_1.default.getSelectedCategory(cid),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             user_1.default.getSettings(req.uid),
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             user_1.default.isPrivileged(req.uid),
         ]);
         let page = 1;
-        if (typeof req.query.page === "string" && !Number.isNaN(parseInt(req.query.page, 10))) {
+        if (typeof req.query.page === 'string' && !Number.isNaN(parseInt(req.query.page, 10))) {
             page = parseInt(req.query.page, 10);
         }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands
         const stop = start + userSettings.topicsPerPage - 1;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         const data = yield topics_1.default.getUnreadTopics({
             cid: cid,
             uid: req.uid,
@@ -44,18 +58,27 @@ function get(req, res) {
             filter: filter,
             query: req.query,
         });
-        const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+        const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) ||
+            req.originalUrl.startsWith(`${relative_path}/unread`));
         const baseUrl = isDisplayedAsHome ? '' : 'unread';
         if (isDisplayedAsHome) {
-            data.title = meta_1.default.config.homePageTitle || '[[pages:home]]';
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            data.title = (meta_1.default.config.homePageTitle || '[[pages:home]]');
         }
         else {
             data.title = '[[pages:unread]]';
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             data.breadcrumbs = helpers_1.default.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
         }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
         data.pagination = pagination_1.default.create(page, data.pageCount, req.query);
         helpers_1.default.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
             req.query.page = Math.max(1, Math.min(data.pageCount, page));
             return helpers_1.default.redirect(res, `/unread?${querystring_1.default.stringify(req.query)}`);
@@ -63,23 +86,30 @@ function get(req, res) {
         data.showSelect = true;
         data.showTopicTools = isPrivileged;
         data.allCategoriesUrl = `${baseUrl}${helpers_1.default.buildQueryString(req.query, 'cid', '')}`;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data.selectedCategory = categoryData.selectedCategory;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         data.selectedCids = categoryData.selectedCids;
         data.selectCategoryLabel = '[[unread:mark_as_read]]';
         data.selectCategoryIcon = 'fa-inbox';
         data.showCategorySelectLabel = true;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         data.filters = helpers_1.default.buildFilters(baseUrl, filter, req.query);
         data.selectedFilter = data.filters.find(filter => filter && filter.selected);
         res.render('unread', data);
     });
 }
 exports.get = get;
-;
 function unreadTotal(req, res, next) {
     return __awaiter(this, void 0, void 0, function* () {
         const filter = req.query.filter || '';
         try {
-            const unreadCount = yield topics_1.default.getTotalUnread(req.uid, filter);
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            const unreadCount = yield (topics_1.default.getTotalUnread(req.uid, filter));
             res.json(unreadCount);
         }
         catch (err) {
@@ -88,83 +118,3 @@ function unreadTotal(req, res, next) {
     });
 }
 exports.unreadTotal = unreadTotal;
-;
-/*
-'use strict';
-
-const nconf = require('nconf');
-const querystring = require('querystring');
-
-const meta = require('../meta');
-const pagination = require('../pagination');
-const user = require('../user');
-const topics = require('../topics');
-const helpers = require('./helpers');
-
-const unreadController = module.exports;
-const relative_path = nconf.get('relative_path');
-
-unreadController.get = async function (req, res) {
-    const { cid } = req.query;
-    const filter = req.query.filter || '';
-
-    const [categoryData, userSettings, isPrivileged] = await Promise.all([
-        helpers.getSelectedCategory(cid),
-        user.getSettings(req.uid),
-        user.isPrivileged(req.uid),
-    ]);
-
-    const page = parseInt(req.query.page, 10) || 1;
-    const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
-    const stop = start + userSettings.topicsPerPage - 1;
-    const data = await topics.getUnreadTopics({
-        cid: cid,
-        uid: req.uid,
-        start: start,
-        stop: stop,
-        filter: filter,
-        query: req.query,
-    });
-
-    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
-    const baseUrl = isDisplayedAsHome ? '' : 'unread';
-
-    if (isDisplayedAsHome) {
-        data.title = meta.config.homePageTitle || '[[pages:home]]';
-    } else {
-        data.title = '[[pages:unread]]';
-        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
-    }
-
-    data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
-    data.pagination = pagination.create(page, data.pageCount, req.query);
-    helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
-
-    if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
-        req.query.page = Math.max(1, Math.min(data.pageCount, page));
-        return helpers.redirect(res, `/unread?${querystring.stringify(req.query)}`);
-    }
-    data.showSelect = true;
-    data.showTopicTools = isPrivileged;
-    data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
-    data.selectedCategory = categoryData.selectedCategory;
-    data.selectedCids = categoryData.selectedCids;
-    data.selectCategoryLabel = '[[unread:mark_as_read]]';
-    data.selectCategoryIcon = 'fa-inbox';
-    data.showCategorySelectLabel = true;
-    data.filters = helpers.buildFilters(baseUrl, filter, req.query);
-    data.selectedFilter = data.filters.find(filter => filter && filter.selected);
-
-    res.render('unread', data);
-};
-
-unreadController.unreadTotal = async function (req, res, next) {
-    const filter = req.query.filter || '';
-    try {
-        const unreadCount = await topics.getTotalUnread(req.uid, filter);
-        res.json(unreadCount);
-    } catch (err) {
-        next(err);
-    }
-};
-*/ 

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -49,7 +49,7 @@ function get(req, res) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands
         const stop = start + userSettings.topicsPerPage - 1;
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const data = yield topics_1.default.getUnreadTopics({
             cid: cid,
             uid: req.uid,
@@ -67,6 +67,8 @@ function get(req, res) {
             data.title = (meta_1.default.config.homePageTitle || '[[pages:home]]');
         }
         else {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             data.title = '[[pages:unread]]';
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -75,30 +77,56 @@ function get(req, res) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.pagination = pagination_1.default.create(page, data.pageCount, req.query);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         helpers_1.default.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
             req.query.page = Math.max(1, Math.min(data.pageCount, page));
             return helpers_1.default.redirect(res, `/unread?${querystring_1.default.stringify(req.query)}`);
         }
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.showSelect = true;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.showTopicTools = isPrivileged;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.allCategoriesUrl = `${baseUrl}${helpers_1.default.buildQueryString(req.query, 'cid', '')}`;
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         data.selectedCategory = categoryData.selectedCategory;
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
         data.selectedCids = categoryData.selectedCids;
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.selectCategoryLabel = '[[unread:mark_as_read]]';
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.selectCategoryIcon = 'fa-inbox';
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.showCategorySelectLabel = true;
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.filters = helpers_1.default.buildFilters(baseUrl, filter, req.query);
+        // The next line calls a function in a module that has not been updated to TS yet
+        /* eslint-disable-next-line
+            @typescript-eslint/no-unsafe-assignment,
+            @typescript-eslint/no-unsafe-member-access,
+            @typescript-eslint/no-unsafe-call,
+            @typescript-eslint/no-unsafe-return */
         data.selectedFilter = data.filters.find(filter => filter && filter.selected);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         res.render('unread', data);
     });
 }

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -1,4 +1,95 @@
-
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.unreadTotal = exports.get = void 0;
+const nconf_1 = __importDefault(require("nconf"));
+const querystring_1 = __importDefault(require("querystring"));
+const meta_1 = __importDefault(require("../meta"));
+const pagination_1 = __importDefault(require("../pagination"));
+const user_1 = __importDefault(require("../user"));
+const topics_1 = __importDefault(require("../topics"));
+const helpers_1 = __importDefault(require("./helpers"));
+const relative_path = nconf_1.default.get('relative_path');
+function get(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { cid } = req.query;
+        const filter = req.query.filter || '';
+        const [categoryData, userSettings, isPrivileged] = yield Promise.all([
+            helpers_1.default.getSelectedCategory(cid),
+            user_1.default.getSettings(req.uid),
+            user_1.default.isPrivileged(req.uid),
+        ]);
+        let page = 1;
+        if (typeof req.query.page === "string" && !Number.isNaN(parseInt(req.query.page, 10))) {
+            page = parseInt(req.query.page, 10);
+        }
+        const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+        const stop = start + userSettings.topicsPerPage - 1;
+        const data = yield topics_1.default.getUnreadTopics({
+            cid: cid,
+            uid: req.uid,
+            start: start,
+            stop: stop,
+            filter: filter,
+            query: req.query,
+        });
+        const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+        const baseUrl = isDisplayedAsHome ? '' : 'unread';
+        if (isDisplayedAsHome) {
+            data.title = meta_1.default.config.homePageTitle || '[[pages:home]]';
+        }
+        else {
+            data.title = '[[pages:unread]]';
+            data.breadcrumbs = helpers_1.default.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
+        }
+        data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+        data.pagination = pagination_1.default.create(page, data.pageCount, req.query);
+        helpers_1.default.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
+        if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+            req.query.page = Math.max(1, Math.min(data.pageCount, page));
+            return helpers_1.default.redirect(res, `/unread?${querystring_1.default.stringify(req.query)}`);
+        }
+        data.showSelect = true;
+        data.showTopicTools = isPrivileged;
+        data.allCategoriesUrl = `${baseUrl}${helpers_1.default.buildQueryString(req.query, 'cid', '')}`;
+        data.selectedCategory = categoryData.selectedCategory;
+        data.selectedCids = categoryData.selectedCids;
+        data.selectCategoryLabel = '[[unread:mark_as_read]]';
+        data.selectCategoryIcon = 'fa-inbox';
+        data.showCategorySelectLabel = true;
+        data.filters = helpers_1.default.buildFilters(baseUrl, filter, req.query);
+        data.selectedFilter = data.filters.find(filter => filter && filter.selected);
+        res.render('unread', data);
+    });
+}
+exports.get = get;
+;
+function unreadTotal(req, res, next) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const filter = req.query.filter || '';
+        try {
+            const unreadCount = yield topics_1.default.getTotalUnread(req.uid, filter);
+            res.json(unreadCount);
+        }
+        catch (err) {
+            next(err);
+        }
+    });
+}
+exports.unreadTotal = unreadTotal;
+;
+/*
 'use strict';
 
 const nconf = require('nconf');
@@ -76,3 +167,4 @@ unreadController.unreadTotal = async function (req, res, next) {
         next(err);
     }
 };
+*/ 

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -28,18 +28,14 @@ function get(req, res) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const [categoryData, userSettings, isPrivileged] = yield Promise.all([
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             helpers_1.default.getSelectedCategory(cid),
             // The next line calls a function in a module that has not been updated to TS yet
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             user_1.default.getSettings(req.uid),
-            // The next line calls a function in a module that has not been updated to TS yet
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             user_1.default.isPrivileged(req.uid),
         ]);
         let page = 1;
-        if (typeof req.query.page === 'string' && !Number.isNaN(parseInt(req.query.page, 10))) {
+        if (typeof req.query.page === 'string' && req.query.page.length > 0) {
             page = parseInt(req.query.page, 10);
         }
         // The next line calls a function in a module that has not been updated to TS yet
@@ -58,8 +54,7 @@ function get(req, res) {
             filter: filter,
             query: req.query,
         });
-        const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) ||
-            req.originalUrl.startsWith(`${relative_path}/unread`));
+        const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
         const baseUrl = isDisplayedAsHome ? '' : 'unread';
         if (isDisplayedAsHome) {
             // The next line calls a function in a module that has not been updated to TS yet
@@ -119,11 +114,10 @@ function get(req, res) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.filters = helpers_1.default.buildFilters(baseUrl, filter, req.query);
         // The next line calls a function in a module that has not been updated to TS yet
-        /* eslint-disable-next-line
-            @typescript-eslint/no-unsafe-assignment,
-            @typescript-eslint/no-unsafe-member-access,
-            @typescript-eslint/no-unsafe-call,
-            @typescript-eslint/no-unsafe-return */
+        /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,
+                                    @typescript-eslint/no-unsafe-member-access,
+                                    @typescript-eslint/no-unsafe-call,
+                                    @typescript-eslint/no-unsafe-return */
         data.selectedFilter = data.filters.find(filter => filter && filter.selected);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/controllers/unread.ts
+++ b/src/controllers/unread.ts
@@ -85,7 +85,7 @@ export async function get(req: CustomRequest, res: Response) {
     if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-        (req.query.page as unknown as number) = Math.max(1, Math.min(data.pageCount, page));
+        req.query.page = (Math.max(1, Math.min(data.pageCount, page))).toString();
         return helpers.redirect(res, `/unread?${querystring.stringify(req.query as ParsedUrlQueryInput)}`);
     }
     // The next line calls a function in a module that has not been updated to TS yet

--- a/src/controllers/unread.ts
+++ b/src/controllers/unread.ts
@@ -14,68 +14,6 @@ interface CustomRequest extends Request {
     uid: string;
 }
 
-interface Pagnation {
-    prev: {
-        page: number,
-        active: boolean
-    },
-    next: {
-        page: number,
-        active: boolean
-    },
-    first: {
-        page: number,
-        active: boolean
-    },
-    last: {
-        page: number,
-        active: boolean
-    },
-    rel: [],
-    pages: [],
-    currentPage: number,
-    pageCount: number,
-}
-
-interface UnreadTopics {
-    showSelect: boolean,
-    nextStart: number,
-    topics: [],
-    topicCount: number,
-    title: string,
-    breadcrumbs:[{
-        text: string,
-        url: string,
-    }],
-    pageCount: number,
-    pagination: Pagnation,
-    showTopicTools: boolean,
-    allCategoriesUrl: string,
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    selectedCategory: any,
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    selectedCids: any,
-    selectCategoryLabel: string,
-    selectCategoryIcon: string,
-    showCategorySelectLabel: boolean,
-    filters: [{
-        name: string,
-        url: string,
-        selected: boolean,
-        filter: string,
-        icon: string,
-    }],
-    selectedFilter: {
-        name: string,
-        url: string,
-        selected: boolean,
-        filter: string,
-        icon: string,
-    },
-}
-
 export async function get(req: CustomRequest, res: Response) {
     const { cid } = req.query;
     const filter = req.query.filter || '';
@@ -105,15 +43,15 @@ export async function get(req: CustomRequest, res: Response) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands
     const stop = start + userSettings.topicsPerPage - 1;
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const data: UnreadTopics = await topics.getUnreadTopics({
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const data = await topics.getUnreadTopics({
         cid: cid,
         uid: req.uid,
         start: start,
         stop: stop,
         filter: filter,
         query: req.query,
-    }) as UnreadTopics;
+    });
 
     const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) ||
     req.originalUrl.startsWith(`${relative_path}/unread`));
@@ -124,6 +62,8 @@ export async function get(req: CustomRequest, res: Response) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.title = (meta.config.homePageTitle || '[[pages:home]]') as string;
     } else {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.title = '[[pages:unread]]';
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -133,32 +73,57 @@ export async function get(req: CustomRequest, res: Response) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.pagination = pagination.create(page, data.pageCount, req.query);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
 
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         (req.query.page as unknown as number) = Math.max(1, Math.min(data.pageCount, page));
         return helpers.redirect(res, `/unread?${querystring.stringify(req.query as ParsedUrlQueryInput)}`);
     }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.showSelect = true;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.showTopicTools = isPrivileged;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
     data.selectedCategory = categoryData.selectedCategory;
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
     data.selectedCids = categoryData.selectedCids;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.selectCategoryLabel = '[[unread:mark_as_read]]';
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.selectCategoryIcon = 'fa-inbox';
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.showCategorySelectLabel = true;
     // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.filters = helpers.buildFilters(baseUrl, filter, req.query);
+    // The next line calls a function in a module that has not been updated to TS yet
+    /* eslint-disable-next-line
+        @typescript-eslint/no-unsafe-assignment,
+        @typescript-eslint/no-unsafe-member-access,
+        @typescript-eslint/no-unsafe-call,
+        @typescript-eslint/no-unsafe-return */
     data.selectedFilter = data.filters.find(filter => filter && filter.selected);
-
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     res.render('unread', data);
 }
 

--- a/src/controllers/unread.ts
+++ b/src/controllers/unread.ts
@@ -21,19 +21,15 @@ export async function get(req: CustomRequest, res: Response) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const [categoryData, userSettings, isPrivileged] = await Promise.all([
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         helpers.getSelectedCategory(cid),
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         user.getSettings(req.uid),
-        // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         user.isPrivileged(req.uid) as boolean,
     ]);
 
     let page = 1;
-    if (typeof req.query.page === 'string' && !Number.isNaN(parseInt(req.query.page, 10))) {
+    if (typeof req.query.page === 'string' && req.query.page.length > 0) {
         page = parseInt(req.query.page, 10);
     }
     // The next line calls a function in a module that has not been updated to TS yet
@@ -53,8 +49,7 @@ export async function get(req: CustomRequest, res: Response) {
         query: req.query,
     });
 
-    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) ||
-    req.originalUrl.startsWith(`${relative_path}/unread`));
+    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
     const baseUrl = isDisplayedAsHome ? '' : 'unread';
 
     if (isDisplayedAsHome) {
@@ -116,11 +111,10 @@ export async function get(req: CustomRequest, res: Response) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.filters = helpers.buildFilters(baseUrl, filter, req.query);
     // The next line calls a function in a module that has not been updated to TS yet
-    /* eslint-disable-next-line
-        @typescript-eslint/no-unsafe-assignment,
-        @typescript-eslint/no-unsafe-member-access,
-        @typescript-eslint/no-unsafe-call,
-        @typescript-eslint/no-unsafe-return */
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,
+                                @typescript-eslint/no-unsafe-member-access,
+                                @typescript-eslint/no-unsafe-call,
+                                @typescript-eslint/no-unsafe-return */
     data.selectedFilter = data.filters.find(filter => filter && filter.selected);
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/controllers/unread.ts
+++ b/src/controllers/unread.ts
@@ -1,0 +1,163 @@
+import nconf from 'nconf';
+import querystring, { ParsedUrlQueryInput } from 'querystring';
+import { Request, Response, NextFunction } from "express";
+
+import meta from '../meta';
+import pagination from '../pagination';
+import user from '../user';
+import topics from '../topics';
+import helpers from './helpers';
+
+interface CustomRequest extends Request {
+    uid?: number;
+}
+
+const relative_path: string = nconf.get('relative_path');
+
+export async function get (req: CustomRequest, res: Response): Promise<void> {
+    const { cid } = req.query;
+    const filter = req.query.filter || '';
+
+    const [categoryData, userSettings, isPrivileged] = await Promise.all([
+        helpers.getSelectedCategory(cid),
+        user.getSettings(req.uid),
+        user.isPrivileged(req.uid),
+    ]);
+
+    let page = 1;
+    if (typeof req.query.page === "string" && !Number.isNaN(parseInt(req.query.page, 10))) {
+        page = parseInt(req.query.page, 10);
+    } 
+    const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+    const stop = start + userSettings.topicsPerPage - 1;
+    const data = await topics.getUnreadTopics({
+        cid: cid,
+        uid: req.uid,
+        start: start,
+        stop: stop,
+        filter: filter,
+        query: req.query,
+    });
+
+    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+    const baseUrl = isDisplayedAsHome ? '' : 'unread';
+
+    if (isDisplayedAsHome) {
+        data.title = meta.config.homePageTitle || '[[pages:home]]';
+    } else {
+        data.title = '[[pages:unread]]';
+        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
+    }
+
+    data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+    data.pagination = pagination.create(page, data.pageCount, req.query);
+    helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
+
+    if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+        (req.query.page as unknown as number)= Math.max(1, Math.min(data.pageCount, page));
+        return helpers.redirect(res, `/unread?${querystring.stringify(req.query as ParsedUrlQueryInput)}`);
+    }
+    data.showSelect = true;
+    data.showTopicTools = isPrivileged;
+    data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
+    data.selectedCategory = categoryData.selectedCategory;
+    data.selectedCids = categoryData.selectedCids;
+    data.selectCategoryLabel = '[[unread:mark_as_read]]';
+    data.selectCategoryIcon = 'fa-inbox';
+    data.showCategorySelectLabel = true;
+    data.filters = helpers.buildFilters(baseUrl, filter, req.query);
+    data.selectedFilter = data.filters.find(filter => filter && filter.selected);
+
+    res.render('unread', data);
+};
+
+export async function unreadTotal (req: CustomRequest, res: Response, next: NextFunction): Promise<void> {
+    const filter = req.query.filter || '';
+    try {
+        const unreadCount = await topics.getTotalUnread(req.uid, filter);
+        res.json(unreadCount);
+    } catch (err) {
+        next(err);
+    }
+};
+
+
+/*
+'use strict';
+
+const nconf = require('nconf');
+const querystring = require('querystring');
+
+const meta = require('../meta');
+const pagination = require('../pagination');
+const user = require('../user');
+const topics = require('../topics');
+const helpers = require('./helpers');
+
+const unreadController = module.exports;
+const relative_path = nconf.get('relative_path');
+
+unreadController.get = async function (req, res) {
+    const { cid } = req.query;
+    const filter = req.query.filter || '';
+
+    const [categoryData, userSettings, isPrivileged] = await Promise.all([
+        helpers.getSelectedCategory(cid),
+        user.getSettings(req.uid),
+        user.isPrivileged(req.uid),
+    ]);
+
+    const page = parseInt(req.query.page, 10) || 1;
+    const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+    const stop = start + userSettings.topicsPerPage - 1;
+    const data = await topics.getUnreadTopics({
+        cid: cid,
+        uid: req.uid,
+        start: start,
+        stop: stop,
+        filter: filter,
+        query: req.query,
+    });
+
+    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+    const baseUrl = isDisplayedAsHome ? '' : 'unread';
+
+    if (isDisplayedAsHome) {
+        data.title = meta.config.homePageTitle || '[[pages:home]]';
+    } else {
+        data.title = '[[pages:unread]]';
+        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
+    }
+
+    data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
+    data.pagination = pagination.create(page, data.pageCount, req.query);
+    helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
+
+    if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
+        req.query.page = Math.max(1, Math.min(data.pageCount, page));
+        return helpers.redirect(res, `/unread?${querystring.stringify(req.query)}`);
+    }
+    data.showSelect = true;
+    data.showTopicTools = isPrivileged;
+    data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
+    data.selectedCategory = categoryData.selectedCategory;
+    data.selectedCids = categoryData.selectedCids;
+    data.selectCategoryLabel = '[[unread:mark_as_read]]';
+    data.selectCategoryIcon = 'fa-inbox';
+    data.showCategorySelectLabel = true;
+    data.filters = helpers.buildFilters(baseUrl, filter, req.query);
+    data.selectedFilter = data.filters.find(filter => filter && filter.selected);
+
+    res.render('unread', data);
+};
+
+unreadController.unreadTotal = async function (req, res, next) {
+    const filter = req.query.filter || '';
+    try {
+        const unreadCount = await topics.getTotalUnread(req.uid, filter);
+        res.json(unreadCount);
+    } catch (err) {
+        next(err);
+    }
+};
+*/

--- a/src/controllers/unread.ts
+++ b/src/controllers/unread.ts
@@ -1,6 +1,6 @@
 import nconf from 'nconf';
 import querystring, { ParsedUrlQueryInput } from 'querystring';
-import { Request, Response, NextFunction } from "express";
+import { Request, Response, NextFunction } from 'express';
 
 import meta from '../meta';
 import pagination from '../pagination';
@@ -8,156 +8,168 @@ import user from '../user';
 import topics from '../topics';
 import helpers from './helpers';
 
+const relative_path: string = nconf.get('relative_path') as string;
+
 interface CustomRequest extends Request {
-    uid?: number;
+    uid: string;
 }
 
-const relative_path: string = nconf.get('relative_path');
+interface Pagnation {
+    prev: {
+        page: number,
+        active: boolean
+    },
+    next: {
+        page: number,
+        active: boolean
+    },
+    first: {
+        page: number,
+        active: boolean
+    },
+    last: {
+        page: number,
+        active: boolean
+    },
+    rel: [],
+    pages: [],
+    currentPage: number,
+    pageCount: number,
+}
 
-export async function get (req: CustomRequest, res: Response): Promise<void> {
+interface UnreadTopics {
+    showSelect: boolean,
+    nextStart: number,
+    topics: [],
+    topicCount: number,
+    title: string,
+    breadcrumbs:[{
+        text: string,
+        url: string,
+    }],
+    pageCount: number,
+    pagination: Pagnation,
+    showTopicTools: boolean,
+    allCategoriesUrl: string,
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    selectedCategory: any,
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    selectedCids: any,
+    selectCategoryLabel: string,
+    selectCategoryIcon: string,
+    showCategorySelectLabel: boolean,
+    filters: [{
+        name: string,
+        url: string,
+        selected: boolean,
+        filter: string,
+        icon: string,
+    }],
+    selectedFilter: {
+        name: string,
+        url: string,
+        selected: boolean,
+        filter: string,
+        icon: string,
+    },
+}
+
+export async function get(req: CustomRequest, res: Response) {
     const { cid } = req.query;
     const filter = req.query.filter || '';
 
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const [categoryData, userSettings, isPrivileged] = await Promise.all([
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         helpers.getSelectedCategory(cid),
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         user.getSettings(req.uid),
-        user.isPrivileged(req.uid),
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        user.isPrivileged(req.uid) as boolean,
     ]);
 
     let page = 1;
-    if (typeof req.query.page === "string" && !Number.isNaN(parseInt(req.query.page, 10))) {
+    if (typeof req.query.page === 'string' && !Number.isNaN(parseInt(req.query.page, 10))) {
         page = parseInt(req.query.page, 10);
-    } 
+    }
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands
     const stop = start + userSettings.topicsPerPage - 1;
-    const data = await topics.getUnreadTopics({
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const data: UnreadTopics = await topics.getUnreadTopics({
         cid: cid,
         uid: req.uid,
         start: start,
         stop: stop,
         filter: filter,
         query: req.query,
-    });
+    }) as UnreadTopics;
 
-    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
+    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) ||
+    req.originalUrl.startsWith(`${relative_path}/unread`));
     const baseUrl = isDisplayedAsHome ? '' : 'unread';
 
     if (isDisplayedAsHome) {
-        data.title = meta.config.homePageTitle || '[[pages:home]]';
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        data.title = (meta.config.homePageTitle || '[[pages:home]]') as string;
     } else {
         data.title = '[[pages:unread]]';
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
     }
 
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
     data.pagination = pagination.create(page, data.pageCount, req.query);
     helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
 
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
-        (req.query.page as unknown as number)= Math.max(1, Math.min(data.pageCount, page));
+        (req.query.page as unknown as number) = Math.max(1, Math.min(data.pageCount, page));
         return helpers.redirect(res, `/unread?${querystring.stringify(req.query as ParsedUrlQueryInput)}`);
     }
     data.showSelect = true;
     data.showTopicTools = isPrivileged;
     data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     data.selectedCategory = categoryData.selectedCategory;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     data.selectedCids = categoryData.selectedCids;
     data.selectCategoryLabel = '[[unread:mark_as_read]]';
     data.selectCategoryIcon = 'fa-inbox';
     data.showCategorySelectLabel = true;
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     data.filters = helpers.buildFilters(baseUrl, filter, req.query);
     data.selectedFilter = data.filters.find(filter => filter && filter.selected);
 
     res.render('unread', data);
-};
+}
 
-export async function unreadTotal (req: CustomRequest, res: Response, next: NextFunction): Promise<void> {
+export async function unreadTotal(req: CustomRequest, res: Response, next: NextFunction) {
     const filter = req.query.filter || '';
     try {
-        const unreadCount = await topics.getTotalUnread(req.uid, filter);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const unreadCount: number = await (topics.getTotalUnread(req.uid, filter)) as number;
         res.json(unreadCount);
     } catch (err) {
         next(err);
     }
-};
-
-
-/*
-'use strict';
-
-const nconf = require('nconf');
-const querystring = require('querystring');
-
-const meta = require('../meta');
-const pagination = require('../pagination');
-const user = require('../user');
-const topics = require('../topics');
-const helpers = require('./helpers');
-
-const unreadController = module.exports;
-const relative_path = nconf.get('relative_path');
-
-unreadController.get = async function (req, res) {
-    const { cid } = req.query;
-    const filter = req.query.filter || '';
-
-    const [categoryData, userSettings, isPrivileged] = await Promise.all([
-        helpers.getSelectedCategory(cid),
-        user.getSettings(req.uid),
-        user.isPrivileged(req.uid),
-    ]);
-
-    const page = parseInt(req.query.page, 10) || 1;
-    const start = Math.max(0, (page - 1) * userSettings.topicsPerPage);
-    const stop = start + userSettings.topicsPerPage - 1;
-    const data = await topics.getUnreadTopics({
-        cid: cid,
-        uid: req.uid,
-        start: start,
-        stop: stop,
-        filter: filter,
-        query: req.query,
-    });
-
-    const isDisplayedAsHome = !(req.originalUrl.startsWith(`${relative_path}/api/unread`) || req.originalUrl.startsWith(`${relative_path}/unread`));
-    const baseUrl = isDisplayedAsHome ? '' : 'unread';
-
-    if (isDisplayedAsHome) {
-        data.title = meta.config.homePageTitle || '[[pages:home]]';
-    } else {
-        data.title = '[[pages:unread]]';
-        data.breadcrumbs = helpers.buildBreadcrumbs([{ text: '[[unread:title]]' }]);
-    }
-
-    data.pageCount = Math.max(1, Math.ceil(data.topicCount / userSettings.topicsPerPage));
-    data.pagination = pagination.create(page, data.pageCount, req.query);
-    helpers.addLinkTags({ url: 'unread', res: req.res, tags: data.pagination.rel });
-
-    if (userSettings.usePagination && (page < 1 || page > data.pageCount)) {
-        req.query.page = Math.max(1, Math.min(data.pageCount, page));
-        return helpers.redirect(res, `/unread?${querystring.stringify(req.query)}`);
-    }
-    data.showSelect = true;
-    data.showTopicTools = isPrivileged;
-    data.allCategoriesUrl = `${baseUrl}${helpers.buildQueryString(req.query, 'cid', '')}`;
-    data.selectedCategory = categoryData.selectedCategory;
-    data.selectedCids = categoryData.selectedCids;
-    data.selectCategoryLabel = '[[unread:mark_as_read]]';
-    data.selectCategoryIcon = 'fa-inbox';
-    data.showCategorySelectLabel = true;
-    data.filters = helpers.buildFilters(baseUrl, filter, req.query);
-    data.selectedFilter = data.filters.find(filter => filter && filter.selected);
-
-    res.render('unread', data);
-};
-
-unreadController.unreadTotal = async function (req, res, next) {
-    const filter = req.query.filter || '';
-    try {
-        const unreadCount = await topics.getTotalUnread(req.uid, filter);
-        res.json(unreadCount);
-    } catch (err) {
-        next(err);
-    }
-};
-*/
+}


### PR DESCRIPTION
Resolves #20 

### Changes
- Converted imports from ```require('moduleName')``` format to ```import name from 'moduleName'```
- Created Custom Request interface to cover the usage of ```uid``` property of the request
- Added types to the parameters of each function 
- Ensured ```req.query.page``` was treated with a consistent type
- Suppressed linting errors due to untranslated JS files

### Testing
- Ran ```npm run lint``` locally and made sure there were no errors 
- Ran ```npm run test``` locally and made sure all tests were passing
- Ran ```./nodebb start``` to make sure the project was still running properly without any errors