### PR TITLE
Converted src/messaging/create.js from JS to TS

### DIFF
--- a/src/messaging/create.js
+++ b/src/messaging/create.js
@@ -1,6 +1,7 @@
 "use strict";
 /* eslint max-len: off */
 /* eslint-disable import/no-import-module-exports */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -18,15 +19,29 @@ const meta_1 = __importDefault(require("../meta"));
 const plugins_1 = __importDefault(require("../plugins"));
 const database_1 = __importDefault(require("../database"));
 const user_1 = __importDefault(require("../user"));
+// I made Messaging be any since it is defined and used many times outside of this file and
+// the type is not defined
+// The next defines a variable as 'any' that is used outside of this file and the type is unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 module.exports = function (Messaging) {
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
     Messaging.sendMessage = (data) => __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment
         yield Messaging.checkContent(data.content);
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment
         const inRoom = yield Messaging.isUserInRoom(data.uid, data.roomId);
         if (!inRoom) {
             throw new Error('[[error:not-allowed]]');
         }
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return
         return yield Messaging.addMessage(data);
     });
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.checkContent = (content) => __awaiter(this, void 0, void 0, function* () {
         if (!content) {
             throw new Error('[[error:invalid-chat-message]]');
@@ -46,11 +61,16 @@ module.exports = function (Messaging) {
             throw new Error(`[[error:chat-message-too-long, ${maximumChatMessageLength}]]`);
         }
     });
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addMessage = (data) => __awaiter(this, void 0, void 0, function* () {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const mid = yield database_1.default.incrObjectField('global', 'nextMid');
         const timestamp = data.timestamp || Date.now();
+        // I made message be any since it is used outside of this file and the type is unknown
+        // The next defines a variable as 'any' that is used outside of this file and the type is unknown
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let message = {
             content: data.content,
             timestamp: timestamp,
@@ -68,6 +88,8 @@ module.exports = function (Messaging) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         yield database_1.default.setObject(`message:${mid}`, message);
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment
         const isNewSet = yield Messaging.isNewSet(data.uid, data.roomId, timestamp);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
@@ -76,10 +98,16 @@ module.exports = function (Messaging) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         uids = yield user_1.default.blocks.filterUids(data.uid, uids);
         yield Promise.all([
+            // The next few lines calls a variable in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             Messaging.addRoomToUsers(data.roomId, uids, timestamp),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             Messaging.addMessageToUsers(data.roomId, uids, mid, timestamp),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             Messaging.markUnread(uids.filter(uid => uid !== String(data.uid)), data.roomId),
         ]);
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const messages = yield Messaging.getMessagesData([mid], data.uid, data.roomId, true);
         if (!messages || !messages[0]) {
             return null;
@@ -92,15 +120,23 @@ module.exports = function (Messaging) {
         yield plugins_1.default.hooks.fire('action:messaging.save', { message: messages[0], data: data });
         return messages[0];
     });
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addSystemMessage = (content, uid, roomId) => __awaiter(this, void 0, void 0, function* () {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const message = yield Messaging.addMessage({
             content: content,
             uid: uid,
             roomId: roomId,
             system: 1,
         });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         Messaging.notifyUsersInRoom(uid, roomId, message);
     });
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addRoomToUsers = (roomId, uids, timestamp) => __awaiter(this, void 0, void 0, function* () {
         if (!uids.length) {
             return;
@@ -110,6 +146,8 @@ module.exports = function (Messaging) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         yield database_1.default.sortedSetsAdd(keys, timestamp, roomId);
     });
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addMessageToUsers = (roomId, uids, mid, timestamp) => __awaiter(this, void 0, void 0, function* () {
         if (!uids.length) {
             return;

--- a/src/messaging/create.ts
+++ b/src/messaging/create.ts
@@ -1,57 +1,67 @@
-"use strict";
 /* eslint max-len: off */
 /* eslint-disable import/no-import-module-exports */
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const meta_1 = __importDefault(require("../meta"));
-const plugins_1 = __importDefault(require("../plugins"));
-const database_1 = __importDefault(require("../database"));
-const user_1 = __importDefault(require("../user"));
-module.exports = function (Messaging) {
-    Messaging.sendMessage = (data) => __awaiter(this, void 0, void 0, function* () {
-        yield Messaging.checkContent(data.content);
-        const inRoom = yield Messaging.isUserInRoom(data.uid, data.roomId);
+
+import meta from '../meta';
+import plugins from '../plugins';
+import db from '../database';
+import user from '../user';
+
+interface MessageData {
+    content:string;
+    uid:string;
+    roomId:string;
+    timestamp?:number;
+    system?:number;
+    ip?:string;
+    mid?:number;
+    newSet?:boolean;
+    deleted?:number;
+}
+
+// I made Messaging be any since it is defined and used many times outside of this file and
+// the type is not defined
+module.exports = function (Messaging: any) {
+    Messaging.sendMessage = async (data: MessageData): Promise<any> => {
+        await Messaging.checkContent(data.content);
+        const inRoom: boolean = await Messaging.isUserInRoom(data.uid, data.roomId);
         if (!inRoom) {
             throw new Error('[[error:not-allowed]]');
         }
-        return yield Messaging.addMessage(data);
-    });
-    Messaging.checkContent = (content) => __awaiter(this, void 0, void 0, function* () {
+
+        return await Messaging.addMessage(data);
+    };
+
+    Messaging.checkContent = async (content: string): Promise<void> => {
         if (!content) {
             throw new Error('[[error:invalid-chat-message]]');
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        const maximumChatMessageLength = meta_1.default.config.maximumChatMessageLength || 1000;
+        const maximumChatMessageLength: number = meta.config.maximumChatMessageLength || 1000;
         content = content.trim();
         let { length } = content;
+
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        ({ content, length } = yield plugins_1.default.hooks.fire('filter:messaging.checkContent', { content, length }));
+        ({ content, length } = await plugins.hooks.fire('filter:messaging.checkContent', { content, length }));
         if (!content) {
             throw new Error('[[error:invalid-chat-message]]');
         }
         if (length > maximumChatMessageLength) {
             throw new Error(`[[error:chat-message-too-long, ${maximumChatMessageLength}]]`);
         }
-    });
-    Messaging.addMessage = (data) => __awaiter(this, void 0, void 0, function* () {
+    };
+
+    Messaging.addMessage = async (data: MessageData): Promise<MessageData> => {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        const mid = yield database_1.default.incrObjectField('global', 'nextMid');
-        const timestamp = data.timestamp || Date.now();
-        let message = {
+        const mid: number = await db.incrObjectField('global', 'nextMid');
+        const timestamp: number = data.timestamp || Date.now();
+
+        // I made message be any since it is used outside of this file and the type is unknown
+        let message: any = {
             content: data.content,
             timestamp: timestamp,
             fromuid: data.uid,
@@ -59,64 +69,73 @@ module.exports = function (Messaging) {
             deleted: 0,
             system: data.system || 0,
         };
+
         if (data.ip) {
             message.ip = data.ip;
         }
+
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        message = yield plugins_1.default.hooks.fire('filter:messaging.save', message);
+        message = await plugins.hooks.fire('filter:messaging.save', message);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        yield database_1.default.setObject(`message:${mid}`, message);
-        const isNewSet = yield Messaging.isNewSet(data.uid, data.roomId, timestamp);
+        await db.setObject(`message:${mid}`, message);
+        const isNewSet: boolean = await Messaging.isNewSet(data.uid, data.roomId, timestamp);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        let uids = yield database_1.default.getSortedSetRange(`chat:room:${data.roomId}:uids`, 0, -1);
+        let uids: string[] = await db.getSortedSetRange(`chat:room:${data.roomId}:uids`, 0, -1);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        uids = yield user_1.default.blocks.filterUids(data.uid, uids);
-        yield Promise.all([
+        uids = await user.blocks.filterUids(data.uid, uids);
+
+        await Promise.all([
             Messaging.addRoomToUsers(data.roomId, uids, timestamp),
             Messaging.addMessageToUsers(data.roomId, uids, mid, timestamp),
             Messaging.markUnread(uids.filter(uid => uid !== String(data.uid)), data.roomId),
         ]);
-        const messages = yield Messaging.getMessagesData([mid], data.uid, data.roomId, true);
+
+        const messages: MessageData[] = await Messaging.getMessagesData([mid], data.uid, data.roomId, true);
         if (!messages || !messages[0]) {
             return null;
         }
+
         messages[0].newSet = isNewSet;
         messages[0].mid = mid;
         messages[0].roomId = data.roomId;
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        yield plugins_1.default.hooks.fire('action:messaging.save', { message: messages[0], data: data });
+        await plugins.hooks.fire('action:messaging.save', { message: messages[0], data: data });
         return messages[0];
-    });
-    Messaging.addSystemMessage = (content, uid, roomId) => __awaiter(this, void 0, void 0, function* () {
-        const message = yield Messaging.addMessage({
+    };
+
+    Messaging.addSystemMessage = async (content: string, uid: string, roomId: string): Promise<void> => {
+        const message: MessageData = await Messaging.addMessage({
             content: content,
             uid: uid,
             roomId: roomId,
             system: 1,
         });
         Messaging.notifyUsersInRoom(uid, roomId, message);
-    });
-    Messaging.addRoomToUsers = (roomId, uids, timestamp) => __awaiter(this, void 0, void 0, function* () {
+    };
+
+    Messaging.addRoomToUsers = async (roomId: string, uids: string[], timestamp: number): Promise<void> => {
         if (!uids.length) {
             return;
         }
+
         const keys = uids.map(uid => `uid:${uid}:chat:rooms`);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        yield database_1.default.sortedSetsAdd(keys, timestamp, roomId);
-    });
-    Messaging.addMessageToUsers = (roomId, uids, mid, timestamp) => __awaiter(this, void 0, void 0, function* () {
+        await db.sortedSetsAdd(keys, timestamp, roomId);
+    };
+
+    Messaging.addMessageToUsers = async (roomId: string, uids: string[], mid: number, timestamp: number): Promise<void> => {
         if (!uids.length) {
             return;
         }
         const keys = uids.map(uid => `uid:${uid}:chat:room:${roomId}:mids`);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-        yield database_1.default.sortedSetsAdd(keys, timestamp, mid);
-    });
+        await db.sortedSetsAdd(keys, timestamp, mid);
+    };
 };

--- a/src/messaging/create.ts
+++ b/src/messaging/create.ts
@@ -1,5 +1,6 @@
 /* eslint max-len: off */
 /* eslint-disable import/no-import-module-exports */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import meta from '../meta';
 import plugins from '../plugins';
@@ -20,17 +21,30 @@ interface MessageData {
 
 // I made Messaging be any since it is defined and used many times outside of this file and
 // the type is not defined
+
+// The next defines a variable as 'any' that is used outside of this file and the type is unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 module.exports = function (Messaging: any) {
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
     Messaging.sendMessage = async (data: MessageData): Promise<any> => {
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment
         await Messaging.checkContent(data.content);
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment
         const inRoom: boolean = await Messaging.isUserInRoom(data.uid, data.roomId);
         if (!inRoom) {
             throw new Error('[[error:not-allowed]]');
         }
 
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return
         return await Messaging.addMessage(data);
     };
 
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.checkContent = async (content: string): Promise<void> => {
         if (!content) {
             throw new Error('[[error:invalid-chat-message]]');
@@ -54,6 +68,8 @@ module.exports = function (Messaging: any) {
         }
     };
 
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addMessage = async (data: MessageData): Promise<MessageData> => {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
@@ -61,6 +77,8 @@ module.exports = function (Messaging: any) {
         const timestamp: number = data.timestamp || Date.now();
 
         // I made message be any since it is used outside of this file and the type is unknown
+        // The next defines a variable as 'any' that is used outside of this file and the type is unknown
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let message: any = {
             content: data.content,
             timestamp: timestamp,
@@ -80,6 +98,8 @@ module.exports = function (Messaging: any) {
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         await db.setObject(`message:${mid}`, message);
+        // The next line calls a variable in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,  @typescript-eslint/no-unsafe-assignment
         const isNewSet: boolean = await Messaging.isNewSet(data.uid, data.roomId, timestamp);
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
@@ -89,11 +109,17 @@ module.exports = function (Messaging: any) {
         uids = await user.blocks.filterUids(data.uid, uids);
 
         await Promise.all([
+            // The next few lines calls a variable in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             Messaging.addRoomToUsers(data.roomId, uids, timestamp),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             Messaging.addMessageToUsers(data.roomId, uids, mid, timestamp),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             Messaging.markUnread(uids.filter(uid => uid !== String(data.uid)), data.roomId),
         ]);
 
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const messages: MessageData[] = await Messaging.getMessagesData([mid], data.uid, data.roomId, true);
         if (!messages || !messages[0]) {
             return null;
@@ -108,16 +134,24 @@ module.exports = function (Messaging: any) {
         return messages[0];
     };
 
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addSystemMessage = async (content: string, uid: string, roomId: string): Promise<void> => {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
         const message: MessageData = await Messaging.addMessage({
             content: content,
             uid: uid,
             roomId: roomId,
             system: 1,
         });
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         Messaging.notifyUsersInRoom(uid, roomId, message);
     };
 
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addRoomToUsers = async (roomId: string, uids: string[], timestamp: number): Promise<void> => {
         if (!uids.length) {
             return;
@@ -129,6 +163,8 @@ module.exports = function (Messaging: any) {
         await db.sortedSetsAdd(keys, timestamp, roomId);
     };
 
+    // The next line utilizes a variable in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     Messaging.addMessageToUsers = async (roomId: string, uids: string[], mid: number, timestamp: number): Promise<void> => {
         if (!uids.length) {
             return;


### PR DESCRIPTION
Resolved issue #16 , Convert src/messaging/create.js from JS to TS. 

# **Changes**
- Converted as many variables in the create file to types. Some include `number`, `string`, `boolean`, and a custom interface to handle the data being passed through, `MessageData`. 
- Added proper return types such as `Promise<void>`, `Promise<MessageData`, and `Promise<boolean>`. 
- Suppressed some linting errors due to untranslated JavaScript. 
# **Tests**
- Ran and passed `npm run lint` , with the only eslint silencing was related to "Messaging" being an any type
- Ran and passed `npm run test`
- Ran `./nodebb start` without error.