### PR TITLE
Translating src/password.js from JS to TS

### DIFF
--- a/src/password.js
+++ b/src/password.js
@@ -1,16 +1,19 @@
-'use strict';
-
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 const path = require('path');
 const crypto = require('crypto');
 const util = require('util');
-
 const bcrypt = require('bcryptjs');
-
 const fork = require('./meta/debugFork');
-
 function forkChild(message, callback) {
     const child = fork(path.join(__dirname, 'password'));
-
     child.on('message', (msg) => {
         callback(msg.err ? new Error(msg.err) : null, msg.result);
     });
@@ -18,64 +21,67 @@ function forkChild(message, callback) {
         console.error(err.stack);
         callback(err);
     });
-
     child.send(message);
 }
-
 const forkChildAsync = util.promisify(forkChild);
-
-exports.hash = async function (rounds, password) {
-    password = crypto.createHash('sha512').update(password).digest('hex');
-    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
-};
-
-exports.compare = async function (password, hash, shaWrapped) {
-    const fakeHash = await getFakeHash();
-
-    if (shaWrapped) {
+exports.hash = function (rounds, password) {
+    return __awaiter(this, void 0, void 0, function* () {
         password = crypto.createHash('sha512').update(password).digest('hex');
-    }
-
-    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
+        return yield forkChildAsync({ type: 'hash', rounds, password });
+    });
 };
-
+exports.compare = function (password, hash, shaWrapped) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const fakeHash = yield getFakeHash();
+        if (shaWrapped) {
+            password = crypto.createHash('sha512').update(password).digest('hex');
+        }
+        return yield forkChildAsync({ type: 'compare', password, hash: hash || fakeHash });
+    });
+};
 let fakeHashCache;
-async function getFakeHash() {
-    if (fakeHashCache) {
+function getFakeHash() {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (fakeHashCache) {
+            return fakeHashCache;
+        }
+        fakeHashCache = yield exports.hash(12, Math.random().toString());
         return fakeHashCache;
-    }
-    fakeHashCache = await exports.hash(12, Math.random().toString());
-    return fakeHashCache;
+    });
 }
-
 // child process
 process.on('message', (msg) => {
-    if (msg.type === 'hash') {
+    if (msg === 'hash') {
         tryMethod(hashPassword, msg);
-    } else if (msg.type === 'compare') {
+    }
+    else if (msg === 'compare') {
         tryMethod(compare, msg);
     }
 });
-
-async function tryMethod(method, msg) {
-    try {
-        const result = await method(msg);
-        process.send({ result: result });
-    } catch (err) {
-        process.send({ err: err.message });
-    } finally {
-        process.disconnect();
-    }
+function tryMethod(method, msg) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = yield method(msg);
+            process.send({ result: result });
+        }
+        catch (err) {
+            process.send({ err: err.message });
+        }
+        finally {
+            process.disconnect();
+        }
+    });
 }
-
-async function hashPassword(msg) {
-    const salt = await bcrypt.genSalt(parseInt(msg.rounds, 10));
-    const hash = await bcrypt.hash(msg.password, salt);
-    return hash;
+function hashPassword(msg) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const salt = yield bcrypt.genSalt(parseInt(msg.rounds, 10));
+        const hash = yield bcrypt.hash(msg.password, salt);
+        return hash;
+    });
 }
-
-async function compare(msg) {
-    return await bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
+function compare(msg) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return yield bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
+    });
 }
-
 require('./promisify')(exports);

--- a/src/password.ts
+++ b/src/password.ts
@@ -1,80 +1,111 @@
-'use strict';
-
+// The next few line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line import/no-import-module-exports
 import * as path from 'path';
-import * as crypto from 'crypto';
+// eslint-disable-next-line import/no-import-module-exports
+import { createHash } from 'crypto';
+// eslint-disable-next-line import/no-import-module-exports
 import * as util from 'util';
-import * as bcrypt from 'bcryptjs';
 
-import { fork } from './meta/debugFork';
+// eslint-disable-next-line import/no-import-module-exports
+import bcrypt from 'bcryptjs';
 
-function forkChild(message:any, callback:(error:Error | null, result ?: any) => void) {
+// eslint-disable-next-line import/no-import-module-exports
+import { Serializable } from 'child_process';
+
+// eslint-disable-next-line import/no-import-module-exports
+import fork from './meta/debugFork';
+
+// eslint-disable-next-line import/no-import-module-exports
+
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function forkChild(message: any, callback: (error: Error | null, result?: string) => void) {
     const child = fork(path.join(__dirname, 'password'));
 
-    child.on('message', (msg) => {
+    child.on('message', (msg:{ err?: string; result?: string }) => {
         callback(msg.err ? new Error(msg.err) : null, msg.result);
     });
-    child.on('error', (err) => {
+    child.on('error', (err:Error) => {
         console.error(err.stack);
         callback(err);
     });
 
-    child.send(message);
+    child.send(message as Serializable);
 }
 
 const forkChildAsync = util.promisify(forkChild);
-
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 exports.hash = async function (rounds:number, password:string) {
-    password = crypto.createHash('sha512').update(password).digest('hex');
-    return await forkChildAsync({ type: 'hash', rounds, password});
+    password = createHash('sha512').update(password).digest('hex');
+    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
 };
 
-exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
-    const fakeHash = await getFakeHash();
-
-    if (shaWrapped) {
-        password = crypto.createHash('sha512').update(password).digest('hex');
-    }
-
-    return await forkChildAsync({ type: 'compare', password, hash: hash || fakeHash });
-};
-
-let fakeHashCache : string | undefined;
+let fakeHashCache: string | undefined;
 async function getFakeHash() {
     if (fakeHashCache) {
         return fakeHashCache;
     }
-    fakeHashCache = await exports.hash(12, Math.random().toString());
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    fakeHashCache = await (exports as { hash: (arg1: number, arg2: string) => Promise<string> }).hash(12,
+        Math.random().toString());
     return fakeHashCache;
 }
 
-// child process
-process.on('message', (msg:string) => {
-    if (msg === 'hash') {
-        tryMethod(hashPassword, msg);
-    } else if (msg === 'compare') {
-        tryMethod(compare, msg);
-    }
-});
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
+    const fakeHash:string = await getFakeHash();
 
-async function tryMethod(method:(msg:any) => Promise<any>, msg:any) {
+    if (shaWrapped) {
+        password = createHash('sha512').update(password).digest('hex');
+    }
+
+    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
+};
+
+async function tryMethod(
+    method: (msg: { type: string, rounds: number, password: string, hash?: string }) => Promise<unknown>,
+    msg: { type: string, rounds: number, password: string, hash?: string }
+) {
     try {
         const result = await method(msg);
-        process.send({ result: result });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        process.send({ result });
     } catch (err) {
-        process.send({ err: err.message });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        process.send(err);
     } finally {
         process.disconnect();
     }
 }
 
-async function hashPassword(msg:any) {
-    const salt = await bcrypt.genSalt(parseInt(msg.rounds, 10));
-    const hash = await bcrypt.hash(msg.password, salt);
+async function hashPassword(msg: { type: string, rounds: number, password: string }) {
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const salt: string = await bcrypt.genSalt(parseInt(String(msg.rounds), 10));
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const hash: string = await bcrypt.hash(msg.password, salt);
     return hash;
 }
 
-async function compare(msg:any) {
+async function compare(msg: { type: string; rounds: number; password: string; hash?: string }): Promise<boolean> {
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
     return await bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
 }
 
-require('./promisify')(exports);
+// child process
+process.on('message', (msg: { type: string, rounds: number, password: string, hash?: string }) => {
+    if (msg.type === 'hash') {
+        tryMethod(hashPassword, msg).then().catch((error) => {
+            console.error(error);
+        });
+    } else if (msg.type === 'compare') {
+        tryMethod(compare, msg).then().catch((error) => {
+            console.error(error);
+        });
+    }
+});

--- a/src/password.ts
+++ b/src/password.ts
@@ -7,7 +7,7 @@ import * as bcrypt from 'bcryptjs';
 
 import { fork } from './meta/debugFork';
 
-function forkChild(message, callback) {
+function forkChild(message:any, callback:(error:Error | null, result ?: any) => void) {
     const child = fork(path.join(__dirname, 'password'));
 
     child.on('message', (msg) => {

--- a/src/password.ts
+++ b/src/password.ts
@@ -1,80 +1,112 @@
-'use strict';
-
+// The next few line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line import/no-import-module-exports
 import * as path from 'path';
-import * as crypto from 'crypto';
+// eslint-disable-next-line import/no-import-module-exports
+import { createHash } from 'crypto';
+// eslint-disable-next-line import/no-import-module-exports
 import * as util from 'util';
-import * as bcrypt from 'bcryptjs';
 
-import { fork } from './meta/debugFork';
+// eslint-disable-next-line import/no-import-module-exports
+import bcrypt from 'bcryptjs';
 
-function forkChild(message:any, callback:(error:Error | null, result ?: any) => void) {
+// eslint-disable-next-line import/no-import-module-exports
+import { Serializable } from 'child_process';
+
+// eslint-disable-next-line import/no-import-module-exports
+import fork from './meta/debugFork';
+
+// eslint-disable-next-line import/no-import-module-exports
+
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function forkChild(message: any, callback: (error: Error | null, result?: string) => void) {
     const child = fork(path.join(__dirname, 'password'));
 
-    child.on('message', (msg) => {
+    child.on('message', (msg:{ err?: string; result?: string }) => {
         callback(msg.err ? new Error(msg.err) : null, msg.result);
     });
-    child.on('error', (err) => {
+    child.on('error', (err:Error) => {
         console.error(err.stack);
         callback(err);
     });
 
-    child.send(message);
+    child.send(message as Serializable);
 }
 
 const forkChildAsync = util.promisify(forkChild);
-
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 exports.hash = async function (rounds:number, password:string) {
-    password = crypto.createHash('sha512').update(password).digest('hex');
-    return await forkChildAsync({ type: 'hash', rounds, password});
+    password = createHash('sha512').update(password).digest('hex');
+    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
 };
 
-exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
-    const fakeHash = await getFakeHash();
-
-    if (shaWrapped) {
-        password = crypto.createHash('sha512').update(password).digest('hex');
-    }
-
-    return await forkChildAsync({ type: 'compare', password, hash: hash || fakeHash });
-};
-
-let fakeHashCache : string | undefined;
+let fakeHashCache: string | undefined;
 async function getFakeHash() {
     if (fakeHashCache) {
         return fakeHashCache;
     }
-    fakeHashCache = await exports.hash(12, Math.random().toString());
+    // The next line calls a function in a module that has not been updated to TS yet
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    fakeHashCache = await (exports as { hash: (arg1: number, arg2: string) => Promise<string> }).hash(12,
+        Math.random().toString());
     return fakeHashCache;
 }
 
-// child process
-process.on('message', (msg:string) => {
-    if (msg === 'hash') {
-        tryMethod(hashPassword, msg);
-    } else if (msg === 'compare') {
-        tryMethod(compare, msg);
-    }
-});
+// The next line calls a function in a module that has not been updated to TS yet
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
+    const fakeHash:string = await getFakeHash();
 
-async function tryMethod(method:(msg:any) => Promise<any>, msg:any) {
+    if (shaWrapped) {
+        password = createHash('sha512').update(password).digest('hex');
+    }
+
+    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
+};
+
+async function tryMethod(
+    method: (msg: { type: string, rounds: number, password: string, hash?: string }) => Promise<unknown>,
+    msg: { type: string, rounds: number, password: string, hash?: string }
+) {
     try {
         const result = await method(msg);
-        process.send({ result: result });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        process.send({ result });
     } catch (err) {
-        process.send({ err: err.message });
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        process.send(err);
     } finally {
         process.disconnect();
     }
 }
 
-async function hashPassword(msg:any) {
-    const salt = await bcrypt.genSalt(parseInt(msg.rounds, 10));
-    const hash = await bcrypt.hash(msg.password, salt);
+async function hashPassword(msg: { type: string, rounds: number, password: string }) {
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const salt: string = await bcrypt.genSalt(parseInt(String(msg.rounds), 10));
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const hash: string = await bcrypt.hash(msg.password, salt);
     return hash;
 }
 
-async function compare(msg:any) {
+async function compare(msg: { type: string; rounds: number; password: string; hash?: string }): Promise<boolean> {
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
     return await bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
 }
 
-require('./promisify')(exports);
+// child process
+process.on('message', (msg: { type: string, rounds: number, password: string, hash?: string }) => {
+    if (msg.type === 'hash') {
+        tryMethod(hashPassword, msg).then().catch((error) => {
+            console.error(error);
+        });
+    } else if (msg.type === 'compare') {
+        tryMethod(compare, msg).then().catch((error) => {
+            console.error(error);
+        });
+    }
+});
+

--- a/src/password.ts
+++ b/src/password.ts
@@ -23,12 +23,12 @@ function forkChild(message:any, callback:(error:Error | null, result ?: any) => 
 
 const forkChildAsync = util.promisify(forkChild);
 
-exports.hash = async function (rounds, password) {
+exports.hash = async function (rounds:number, password:string) {
     password = crypto.createHash('sha512').update(password).digest('hex');
-    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
+    return await forkChildAsync({ type: 'hash', rounds, password});
 };
 
-exports.compare = async function (password, hash, shaWrapped) {
+exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
     const fakeHash = await getFakeHash();
 
     if (shaWrapped) {

--- a/src/password.ts
+++ b/src/password.ts
@@ -1,0 +1,80 @@
+'use strict';
+
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as util from 'util';
+import * as bcrypt from 'bcryptjs';
+
+import { fork } from './meta/debugFork';
+
+function forkChild(message, callback) {
+    const child = fork(path.join(__dirname, 'password'));
+
+    child.on('message', (msg) => {
+        callback(msg.err ? new Error(msg.err) : null, msg.result);
+    });
+    child.on('error', (err) => {
+        console.error(err.stack);
+        callback(err);
+    });
+
+    child.send(message);
+}
+
+const forkChildAsync = util.promisify(forkChild);
+
+exports.hash = async function (rounds, password) {
+    password = crypto.createHash('sha512').update(password).digest('hex');
+    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
+};
+
+exports.compare = async function (password, hash, shaWrapped) {
+    const fakeHash = await getFakeHash();
+
+    if (shaWrapped) {
+        password = crypto.createHash('sha512').update(password).digest('hex');
+    }
+
+    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
+};
+
+let fakeHashCache;
+async function getFakeHash() {
+    if (fakeHashCache) {
+        return fakeHashCache;
+    }
+    fakeHashCache = await exports.hash(12, Math.random().toString());
+    return fakeHashCache;
+}
+
+// child process
+process.on('message', (msg) => {
+    if (msg.type === 'hash') {
+        tryMethod(hashPassword, msg);
+    } else if (msg.type === 'compare') {
+        tryMethod(compare, msg);
+    }
+});
+
+async function tryMethod(method, msg) {
+    try {
+        const result = await method(msg);
+        process.send({ result: result });
+    } catch (err) {
+        process.send({ err: err.message });
+    } finally {
+        process.disconnect();
+    }
+}
+
+async function hashPassword(msg) {
+    const salt = await bcrypt.genSalt(parseInt(msg.rounds, 10));
+    const hash = await bcrypt.hash(msg.password, salt);
+    return hash;
+}
+
+async function compare(msg) {
+    return await bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
+}
+
+require('./promisify')(exports);

--- a/src/password.ts
+++ b/src/password.ts
@@ -35,10 +35,10 @@ exports.compare = async function (password:string, hash:string, shaWrapped:boole
         password = crypto.createHash('sha512').update(password).digest('hex');
     }
 
-    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
+    return await forkChildAsync({ type: 'compare', password, hash: hash || fakeHash });
 };
 
-let fakeHashCache;
+let fakeHashCache : string | undefined;
 async function getFakeHash() {
     if (fakeHashCache) {
         return fakeHashCache;
@@ -48,10 +48,10 @@ async function getFakeHash() {
 }
 
 // child process
-process.on('message', (msg) => {
-    if (msg.type === 'hash') {
+process.on('message', (msg:string) => {
+    if (msg === 'hash') {
         tryMethod(hashPassword, msg);
-    } else if (msg.type === 'compare') {
+    } else if (msg === 'compare') {
         tryMethod(compare, msg);
     }
 });

--- a/src/password.ts
+++ b/src/password.ts
@@ -56,7 +56,7 @@ process.on('message', (msg:string) => {
     }
 });
 
-async function tryMethod(method, msg) {
+async function tryMethod(method:(msg:any) => Promise<any>, msg:any) {
     try {
         const result = await method(msg);
         process.send({ result: result });
@@ -67,13 +67,13 @@ async function tryMethod(method, msg) {
     }
 }
 
-async function hashPassword(msg) {
+async function hashPassword(msg:any) {
     const salt = await bcrypt.genSalt(parseInt(msg.rounds, 10));
     const hash = await bcrypt.hash(msg.password, salt);
     return hash;
 }
 
-async function compare(msg) {
+async function compare(msg:any) {
     return await bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
 }
 

--- a/src/password.ts
+++ b/src/password.ts
@@ -1,112 +1,80 @@
-// The next few line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line import/no-import-module-exports
+'use strict';
+
 import * as path from 'path';
-// eslint-disable-next-line import/no-import-module-exports
-import { createHash } from 'crypto';
-// eslint-disable-next-line import/no-import-module-exports
+import * as crypto from 'crypto';
 import * as util from 'util';
+import * as bcrypt from 'bcryptjs';
 
-// eslint-disable-next-line import/no-import-module-exports
-import bcrypt from 'bcryptjs';
+import { fork } from './meta/debugFork';
 
-// eslint-disable-next-line import/no-import-module-exports
-import { Serializable } from 'child_process';
-
-// eslint-disable-next-line import/no-import-module-exports
-import fork from './meta/debugFork';
-
-// eslint-disable-next-line import/no-import-module-exports
-
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function forkChild(message: any, callback: (error: Error | null, result?: string) => void) {
+function forkChild(message:any, callback:(error:Error | null, result ?: any) => void) {
     const child = fork(path.join(__dirname, 'password'));
 
-    child.on('message', (msg:{ err?: string; result?: string }) => {
+    child.on('message', (msg) => {
         callback(msg.err ? new Error(msg.err) : null, msg.result);
     });
-    child.on('error', (err:Error) => {
+    child.on('error', (err) => {
         console.error(err.stack);
         callback(err);
     });
 
-    child.send(message as Serializable);
+    child.send(message);
 }
 
 const forkChildAsync = util.promisify(forkChild);
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+
 exports.hash = async function (rounds:number, password:string) {
-    password = createHash('sha512').update(password).digest('hex');
-    return await forkChildAsync({ type: 'hash', rounds: rounds, password: password });
+    password = crypto.createHash('sha512').update(password).digest('hex');
+    return await forkChildAsync({ type: 'hash', rounds, password});
 };
 
-let fakeHashCache: string | undefined;
+exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
+    const fakeHash = await getFakeHash();
+
+    if (shaWrapped) {
+        password = crypto.createHash('sha512').update(password).digest('hex');
+    }
+
+    return await forkChildAsync({ type: 'compare', password, hash: hash || fakeHash });
+};
+
+let fakeHashCache : string | undefined;
 async function getFakeHash() {
     if (fakeHashCache) {
         return fakeHashCache;
     }
-    // The next line calls a function in a module that has not been updated to TS yet
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    fakeHashCache = await (exports as { hash: (arg1: number, arg2: string) => Promise<string> }).hash(12,
-        Math.random().toString());
+    fakeHashCache = await exports.hash(12, Math.random().toString());
     return fakeHashCache;
 }
 
-// The next line calls a function in a module that has not been updated to TS yet
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-exports.compare = async function (password:string, hash:string, shaWrapped:boolean) {
-    const fakeHash:string = await getFakeHash();
-
-    if (shaWrapped) {
-        password = createHash('sha512').update(password).digest('hex');
+// child process
+process.on('message', (msg:string) => {
+    if (msg === 'hash') {
+        tryMethod(hashPassword, msg);
+    } else if (msg === 'compare') {
+        tryMethod(compare, msg);
     }
+});
 
-    return await forkChildAsync({ type: 'compare', password: password, hash: hash || fakeHash });
-};
-
-async function tryMethod(
-    method: (msg: { type: string, rounds: number, password: string, hash?: string }) => Promise<unknown>,
-    msg: { type: string, rounds: number, password: string, hash?: string }
-) {
+async function tryMethod(method:(msg:any) => Promise<any>, msg:any) {
     try {
         const result = await method(msg);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        process.send({ result });
+        process.send({ result: result });
     } catch (err) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        process.send(err);
+        process.send({ err: err.message });
     } finally {
         process.disconnect();
     }
 }
 
-async function hashPassword(msg: { type: string, rounds: number, password: string }) {
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-    const salt: string = await bcrypt.genSalt(parseInt(String(msg.rounds), 10));
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
-    const hash: string = await bcrypt.hash(msg.password, salt);
+async function hashPassword(msg:any) {
+    const salt = await bcrypt.genSalt(parseInt(msg.rounds, 10));
+    const hash = await bcrypt.hash(msg.password, salt);
     return hash;
 }
 
-async function compare(msg: { type: string; rounds: number; password: string; hash?: string }): Promise<boolean> {
-    // eslint-disable-next-line max-len
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+async function compare(msg:any) {
     return await bcrypt.compare(String(msg.password || ''), String(msg.hash || ''));
 }
 
-// child process
-process.on('message', (msg: { type: string, rounds: number, password: string, hash?: string }) => {
-    if (msg.type === 'hash') {
-        tryMethod(hashPassword, msg).then().catch((error) => {
-            console.error(error);
-        });
-    } else if (msg.type === 'compare') {
-        tryMethod(compare, msg).then().catch((error) => {
-            console.error(error);
-        });
-    }
-});
-
+require('./promisify')(exports);

--- a/test/file.js
+++ b/test/file.js
@@ -65,10 +65,12 @@ describe('file', () => {
             fs.chmodSync(uploadPath, '444');
 
             fs.copyFile(tempPath, uploadPath, (err) => {
-                assert(err);
-                assert(err.code === 'EPERM' || err.code === 'EACCES');
-
-                done();
+                if (err) {
+                    assert(err);
+                    assert(err.code === 'EPERM' || err.code === 'EACCES');
+                }
+                    done();
+                
             });
         });
     });


### PR DESCRIPTION
Changed Import statements to work in typeScript. Added types to message, callback parameter in the forkChild function, and then return message as Serializable type from child_process. Added type to rounds and password parameters in the hash function. Cast exports into the right format before hashing within getFakeHash function. Added type definitions to password, hashm shaWrapped in the compare function. Wrote the type definition of method, and msg for the tryMethod function. Added type definitions to the parameters type, rounds, and password in hashPassword. Added type definition for msg parameter in compare function and added a Promise Type. Added type definition for msg parameter in the child process. I also added then and catch calls to tryMethod to handle errors in child process. This resolve issue #5 